### PR TITLE
Api Proposal

### DIFF
--- a/examples/customize-filtering/index.js
+++ b/examples/customize-filtering/index.js
@@ -8,13 +8,7 @@ class Example extends React.Component {
   render() {
 
     const columns = [
-      {
-        name: "Name",
-        options: {
-          filter: false,
-          sort: true,
-        }
-      },
+      // A column in the current configuration object api
       {
         name: "Birthday",
         options: {
@@ -46,50 +40,32 @@ class Example extends React.Component {
             );
           },
         }
-      },
-      {
-        name: "Company",
-        options: {
-          filter: true,
-          sort: false,
-        }
-      },
-      {
-        name: "City",
-        options: {
-          filter: true,
-          sort: false,
-        }
-      },
-      {
-        name: "State",
-        options: {
-          filter: true,
-          sort: false,
-        }
-      },
-    ];
-
-    const data = [
-      ["Joe James", 1543941056517, "Test Corp", "Yonkers", "NY"],
-      ["John Walsh", 1503541556517, "Test Corp", "Hartford", "CT"],
-      ["Bob Herm", 1000041556517, "Test Corp", "Tampa", "FL"],
-      ["James Houston", 800041556517, "Test Corp", "Dallas", "TX"],
-    ];
-
-    const options = {
-      filter: true,
-      filterType: 'dropdown',
-      responsive: 'stacked',
-      customSort: (data, colIndex, order) => {
-        return data.sort((a, b) => {
-          return a.data[colIndex].length > b.data[colIndex].length * (order === "asc" ? -1 : 1);
-        });
       }
-    };
+    ];
 
     return (
-      <MUIDataTable title={"Survey Scores"} data={data} columns={columns} options={options}/>
+      <MUIDataTable>
+        {/*This describes the same column as above as React component*/}
+        <MUIDataTableColumn
+          name="Birthday"
+          filter
+          sort
+          // Its possible to reuse the internal components for own components
+          Cell={(x) => <MUIDataTableCell>{new Date(x).toISOString()}</MUIDataTableCell>}
+          FilterValue={(x) => <b>{new Date(x).toISOString()}</b>}
+          FilterControl={(filterValues, onChange, className) => (
+            <TextField
+              id="Birthday"
+              key="Birthday"
+              label="Birthday"
+              className={className}
+              type="date"
+              value={filterValues[0] || "1995-05-01"}
+              onChange={(e) => onChange([e.target.value])}
+            />
+          )}
+        />
+      </MUIDataTable>
     );
 
   }

--- a/examples/customize-filtering/proposal2.js
+++ b/examples/customize-filtering/proposal2.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import MUIDataTable from "../../src/";
 import TextField from "@material-ui/core/TextField";
+import classnames from "classnames";
 
 class Example extends React.Component {
 
@@ -43,39 +44,59 @@ class Example extends React.Component {
       }
     ];
 
+    /*Same component, this time with children instead of render props*/
+    /*All MUIDataTable.* components will not actually be rendered, they're just containers for the API*/
     return (
       <MUIDataTable>
 
-        {/*Same component, this time with children instead of render props*/}
+        <MUIDataTable.Row>
+          {/*called for each row can do formatting or even wrapping in custom components*/}
+          {(value, children) => (
+            <MUIDataTableRow className={classnames({'isActive': value[1].isActive})}
+                             style={{color: value[1].isActive ? "red" : "blue"}}>
+              {children}
+            </MUIDataTableRow>
+          )}
+        </MUIDataTable.Row>
+
         <MUIDataTableColumn
           name="Birthday"
           filter
           sort
         >
-          {/*// Its possible to reuse the internal components for own components*/}
-          <MUIDataTableCell>
-            {(x) => new Date(x).toISOString()}
-          </MUIDataTableCell>
-
-          {/*// Its possible to reuse the internal components for own components*/}
-          <MUIDataTableFilterValue>
-            {(x) => new Date(x).toISOString()}
-          </MUIDataTableFilterValue>
-
-          <MUIDataTableFilterControl>
-            {(filterValues, onChange, className) => (
-              <TextField
-                id="Birthday"
-                key="Birthday"
-                label="Birthday"
-                className={className}
-                type="date"
-                value={filterValues[0] || "1995-05-01"}
-                onChange={(e) => onChange([e.target.value])}
-              />
+          <MUIDataTable.Cell>
+            {(x) => (
+              // Its possible to reuse the internal components for own components*/
+              <MUIDataTableCell className={classnames({'isActive': x.isActive})}>
+                {new Date(x).toISOString()}
+              </MUIDataTableCell>
             )}
-          </MUIDataTableFilterControl>
+          </MUIDataTable.Cell>
 
+
+          <MUIDataTable.Cell>
+            {(x) => (
+              <MUIDataTableFilterValue>
+                {new Date(x).toISOString()}
+              </MUIDataTableFilterValue>
+            )}
+          </MUIDataTable.Cell>
+
+          <MUIDataTable.Cell>
+            {(filterValues, onChange, className) => (
+              <MUIDataTableFilterControl>
+                <TextField
+                  id="Birthday"
+                  key="Birthday"
+                  label="Birthday"
+                  className={className}
+                  type="date"
+                  value={filterValues[0] || "1995-05-01"}
+                  onChange={(e) => onChange([e.target.value])}
+                />
+              </MUIDataTableFilterControl>
+            )}
+          </MUIDataTable.Cell>
 
         </MUIDataTableColumn>
 

--- a/examples/customize-filtering/proposal2.js
+++ b/examples/customize-filtering/proposal2.js
@@ -1,0 +1,91 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import MUIDataTable from "../../src/";
+import TextField from "@material-ui/core/TextField";
+
+class Example extends React.Component {
+
+  render() {
+
+    const columns = [
+      // A column in the current configuration object api
+      {
+        name: "Birthday",
+        options: {
+          filter: true,
+          sort: true,
+          customBodyRender: (x) => <b>{new Date(x).toISOString()}</b>,
+          customFilterValueRender: (filterValue) => {
+            return <b>{new Date(filterValue).toISOString().split('T')[0]}</b>;
+          },
+          customFilterFn: (filterValues, columnValue) => {
+            return new Date(filterValues[0]).getTime() >= new Date(columnValue).getTime();
+          },
+          customFilterRender: (filterValues, onChange, className) => {
+            return (
+              <TextField
+                id="Birthday"
+                key="Birthday"
+                label="Birthday"
+                className={className}
+                type="date"
+                value={filterValues[0] || "1995-05-01"}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                /* DO NOT FORGET TO CALL THE `onChange` METHOD! */
+                /* TYPE MULTISELECT MUST RETURN AN ARRAY!! */
+                onChange={(e) => onChange([e.target.value])}
+              />
+            );
+          },
+        }
+      }
+    ];
+
+    return (
+      <MUIDataTable>
+
+        {/*Same component, this time with children instead of render props*/}
+        <MUIDataTableColumn
+          name="Birthday"
+          filter
+          sort
+        >
+          {/*// Its possible to reuse the internal components for own components*/}
+          <MUIDataTableCell>
+            {(x) => new Date(x).toISOString()}
+          </MUIDataTableCell>
+
+          {/*// Its possible to reuse the internal components for own components*/}
+          <MUIDataTableFilterValue>
+            {(x) => new Date(x).toISOString()}
+          </MUIDataTableFilterValue>
+
+          <MUIDataTableFilterControl>
+            {(filterValues, onChange, className) => (
+              <TextField
+                id="Birthday"
+                key="Birthday"
+                label="Birthday"
+                className={className}
+                type="date"
+                value={filterValues[0] || "1995-05-01"}
+                onChange={(e) => onChange([e.target.value])}
+              />
+            )}
+          </MUIDataTableFilterControl>
+
+
+        </MUIDataTableColumn>
+
+        <MUIDataTableColumn>
+          {/*next columns ...*/}
+        </MUIDataTableColumn>
+      </MUIDataTable>
+    );
+
+  }
+}
+
+ReactDOM.render(<Example/>, document.getElementById("app-root"));

--- a/src/MUIDataTableColumn.js
+++ b/src/MUIDataTableColumn.js
@@ -1,0 +1,98 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Chip from "@material-ui/core/Chip";
+import {withStyles} from "@material-ui/core/styles";
+import InputLabel from "@material-ui/core/InputLabel/InputLabel";
+import Select from "@material-ui/core/Select/Select";
+import Input from "@material-ui/core/Input/Input";
+import MenuItem from "@material-ui/core/MenuItem/MenuItem";
+import FormControl from "@material-ui/core/FormControl/FormControl";
+
+const defaultFilterListStyles = {
+  root: {
+    display: "flex",
+    justifyContent: "left",
+    flexWrap: "wrap",
+    margin: "0px 16px 0px 16px",
+  },
+  chip: {
+    margin: "8px 8px 0px 0px",
+  },
+};
+
+class MUIDataTableCell extends React.Component {
+  render() {
+    const {classes, children} = this.props;
+
+    return <span>{children}</span>;
+  }
+}
+
+class MUIDataTableFilterValue extends React.Component {
+  render() {
+    const {classes, value, label, index, filterUpdate} = this.props;
+
+    return <Chip
+      label={label}
+      key={index}
+      onDelete={filterUpdate(index, value, "checkbox")}
+      className={classes.chip}
+    />;
+  }
+}
+
+class MUIDataTableFilterControl extends React.Component {
+  render() {
+    const {classes, filterValues, onChange, column, index} = this.props;
+
+    return (
+      <FormControl className={classes.selectFormControl} key={index}>
+        <InputLabel htmlFor={column.name}>{column.name}</InputLabel>
+        <Select
+          value={filterValues.toString() || textLabels.all}
+          name={column.name}
+          onChange={event => onChange(index, event.target.value)}
+          input={<Input name={column.name} id={column.name}/>}>
+          <MenuItem value={textLabels.all} key={0}>
+            {textLabels.all}
+          </MenuItem>
+          {filterData[index].map((filterColumn, filterIndex) => (
+            <MenuItem value={filterColumn} key={filterIndex + 1}>
+              {filterColumn !== null ? filterColumn.toString() : ""}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    );
+  }
+}
+
+class MUIDataTableColumn extends React.Component {
+  static propTypes = {
+    name: PropTypes.string,
+    display: PropTypes.bool,
+    filter: PropTypes.bool,
+    sort: PropTypes.bool,
+    download: PropTypes.bool,
+    Head: PropTypes.element,
+    Cell: PropTypes.element,
+    FilterValue: PropTypes.element,
+    FilterControl: PropTypes.element,
+  };
+
+  render() {
+    const {
+            classes,
+            // Default values if no custom render function provided
+            FilterValue   = (x) => <MUIDataTableFilterValue value={x} label={x.toString}/>,
+            FilterControl = (filterValues, onChange) => <MUIDataTableFilterControl filterValues={filterValues} onChange={onChange}/>,
+            Head          = (defaults) => <MUIDataTableHead  {...defaults}/>,
+            Cell          = (x) => <MUIDataTableCell>{x}</MUIDataTableCell>,
+          } = this.props;
+
+    // not sure what the component would return as it is only a container
+    return null;
+  }
+}
+
+export default withStyles(defaultFilterListStyles, {name: "MUIDataTableColumn"})(MUIDataTableColumn);


### PR DESCRIPTION
This shows a proposal on how to make the Column API more cleaner.

It basically changes the column options from a configuration object to a React component that is a children of the table

All options are provided via props and all customizable elements can be provided via render functions.
All customizable elements use internal components to render, these components are exported and can be reused in the custom render function

This gives maximum control over what gets rendered for one column, while staying relatively close to material-ui API

Note: This is non-functional "pseudo-code"